### PR TITLE
Update bootstrap script to inclide namespace watching changes

### DIFF
--- a/lib/amrc/factoryplus/krbkeys/bootstrap.py
+++ b/lib/amrc/factoryplus/krbkeys/bootstrap.py
@@ -40,7 +40,7 @@ class KrbKeysBs:
 
         logging.info(f"Creating keytab for {op}")
         kt = self.kadm.create_keytab([op])
-        self.k8s.update_secret(ns=self.namespace, key=self.keytabs, name=self.ktname, value=kt)
+        self.k8s.update_secret(ns=self.namespace, key=self.ktname, name=self.keytabs, value=kt)
 
     def run(self):
         for s in self.secrets:

--- a/lib/amrc/factoryplus/krbkeys/bootstrap.py
+++ b/lib/amrc/factoryplus/krbkeys/bootstrap.py
@@ -32,7 +32,7 @@ class KrbKeysBs:
 
     def ensure_keytab(self):
         op = self.principal
-        kt = self.k8s.read_secret(key=self.keytabs, name=self.ktname, ns=self.namespace)
+        kt = self.k8s.read_secret(ns=self.namespace, name=self.keytabs, key=self.ktname)
 
         if self.kadm.princ_in_keytab(op, kt):
             logging.info(f"Keytab for {op} already exists.")
@@ -40,7 +40,7 @@ class KrbKeysBs:
 
         logging.info(f"Creating keytab for {op}")
         kt = self.kadm.create_keytab([op])
-        self.k8s.update_secret(ns=self.namespace, key=self.keytabs, name=self.ktname, value=kt)
+        self.k8s.update_secret(ns=self.namespace, name=self.keytabs, key=self.ktname, value=kt)
 
     def run(self):
         for s in self.secrets:

--- a/lib/amrc/factoryplus/krbkeys/bootstrap.py
+++ b/lib/amrc/factoryplus/krbkeys/bootstrap.py
@@ -40,7 +40,7 @@ class KrbKeysBs:
 
         logging.info(f"Creating keytab for {op}")
         kt = self.kadm.create_keytab([op])
-        self.k8s.update_secret(ns=self.namespace, key=self.ktname, name=self.keytabs, value=kt)
+        self.k8s.update_secret(ns=self.namespace, key=self.keytabs, name=self.ktname, value=kt)
 
     def run(self):
         for s in self.secrets:

--- a/lib/amrc/factoryplus/krbkeys/bootstrap.py
+++ b/lib/amrc/factoryplus/krbkeys/bootstrap.py
@@ -15,22 +15,24 @@ import kadmin_local as kadmin
 from .kadmin import Kadm
 from .kubernetes import K8s
 
+
 class KrbKeysBs:
-    def __init__ (self, namespace, keytabs, secrets, principal, ktname):
+    def __init__(self, namespace, keytabs, secrets, principal, ktname):
         self.keytabs = keytabs
+        self.namespace = namespace
         self.secrets = secrets
         self.principal = principal
         self.ktname = ktname
-        
+
         kadm = kadmin.local()
         self.kadm = Kadm("bootstrap", kadm=kadm)
 
         k8s.config.load_incluster_config()
         self.k8s = K8s()
 
-    def ensure_keytab (self):
+    def ensure_keytab(self):
         op = self.principal
-        kt = self.k8s.read_secret(self.keytabs, self.ktname)
+        kt = self.k8s.read_secret(key=self.keytabs, name=self.ktname, ns=self.namespace)
 
         if self.kadm.princ_in_keytab(op, kt):
             logging.info(f"Keytab for {op} already exists.")
@@ -38,22 +40,23 @@ class KrbKeysBs:
 
         logging.info(f"Creating keytab for {op}")
         kt = self.kadm.create_keytab([op])
-        self.k8s.update_secret(self.keytabs, self.ktname, kt)
+        self.k8s.update_secret(ns=self.namespace, key=self.keytabs, name=self.ktname, value=kt)
 
-    def run (self):
+    def run(self):
         for s in self.secrets:
-            self.k8s.find_secret(s)
-    
+            self.k8s.find_secret(name=s, ns=self.namespace)
+
         self.ensure_keytab()
-        
+
+
 if __name__ == "__main__":
     logging.getLogger().setLevel("INFO")
 
     app = KrbKeysBs(
-        namespace = os.environ["NAMESPACE"],
-        keytabs = os.environ["KEYTABS_SECRET"],
-        secrets = [os.environ["PASSWORDS_SECRET"]],
-        principal = os.environ["OP_PRINCIPAL"],
-        ktname = os.environ["OP_KEYTAB"])
+        namespace=os.environ["NAMESPACE"],
+        keytabs=os.environ["KEYTABS_SECRET"],
+        secrets=[os.environ["PASSWORDS_SECRET"]],
+        principal=os.environ["OP_PRINCIPAL"],
+        ktname=os.environ["OP_KEYTAB"])
 
     app.run()


### PR DESCRIPTION
I appears as though the bootstrap script that runds when the cluster first starts didn't include the changes for multi-namespace watching.

This PR adds the required named arguments.