### PR TITLE
Seal secrets to edge clusters.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 -include config.mk
 
-version?=1.0.1
+version?=1.0.3
 suffix?=
 registry?=ghcr.io/amrc-factoryplus
 repo?=acs-kerberos-keys

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,8 @@ deploy: all restart logs
 
 restart:
 	kubectl rollout restart deploy/"${deployment}"
-	sleep 3
+	kubectl rollout status deploy/"${deployment}"
+	sleep 2
 
 logs:
 	kubectl logs -f deploy/"${deployment}" -c operator

--- a/crd/kerberos-keys.yaml
+++ b/crd/kerberos-keys.yaml
@@ -28,6 +28,9 @@ spec:
                 -   name: SealWith
                     jsonPath: ".spec.sealWith"
                     type: string
+                -   name: Cluster
+                    jsonPath: ".spec.cluster"
+                    type: string
             schema:
                 openAPIV3Schema:
                     type: object
@@ -38,7 +41,7 @@ spec:
                             x-kubernetes-validations:
                                 - rule: "self.type in ['Random', 'Disabled'] || !has(self.additionalPrincipals)"
                                 - rule: "self.type in ['Random', 'Disabled'] || !has(self.keepOldKeys)"
-                                - rule: "has(self.secret) || !has(self.sealWith)"
+                                - rule: "has(self.secret) || !(has(self.sealWith) || has(self.cluster))"
                                 - rule: "has(self.secret) || self.type in ['Disabled', 'Random', 'Password', 'PresetPassword']"
                             required: [type, principal]
                             properties:
@@ -87,6 +90,23 @@ spec:
                                         object.
                                     type: string
                                     pattern: "^[a-z0-9.-]+/[a-zA-Z0-9._-]+$"
+                                cluster:
+                                    description: >
+                                        The remote cluster to send the secret to. The secret itself
+                                        will be handed over to the Edge Deployment operator for
+                                        transfer to the remote cluster.
+                                    type: object
+                                    required: [uuid]
+                                    properties:
+                                        uuid:
+                                            description: The cluster UUID.
+                                            type: string
+                                            format: uuid
+                                        namespace:
+                                            description: >
+                                                The namespace to seal the secret into. Defaults to
+                                                the cluster default namespace from the ConfigDB.
+                                            type: string
                         status:
                             type: object
                             x-kubernetes-preserve-unknown-fields: true

--- a/lib/amrc/factoryplus/krbkeys/__init__.py
+++ b/lib/amrc/factoryplus/krbkeys/__init__.py
@@ -11,6 +11,8 @@ import  secrets
 
 import  kopf
 
+from    amrc.factoryplus    import ServiceClient
+
 from .context       import Context
 from .event         import RekeyEvent, TrimKeysEvent
 from .util          import Identifiers, log
@@ -25,6 +27,7 @@ class KrbKeys:
         self.presets = env["PRESETS_SECRET"]
         self.expire_old_keys = int(env.get("EXPIRE_OLD_KEYS", 86400))
         self.kadmin_ccache = env.get("KADMIN_CCNAME", None)
+        self.fplus = ServiceClient(env=env)
 
     def register_handlers (self):
         log("Registering handlers")

--- a/lib/amrc/factoryplus/krbkeys/__init__.py
+++ b/lib/amrc/factoryplus/krbkeys/__init__.py
@@ -24,6 +24,7 @@ class KrbKeys:
         self.passwords = env["PASSWORDS_SECRET"]
         self.presets = env["PRESETS_SECRET"]
         self.expire_old_keys = int(env.get("EXPIRE_OLD_KEYS", 86400))
+        self.kadmin_ccache = env.get("KADMIN_CCNAME", None)
 
     def register_handlers (self):
         log("Registering handlers")

--- a/lib/amrc/factoryplus/krbkeys/context.py
+++ b/lib/amrc/factoryplus/krbkeys/context.py
@@ -45,7 +45,7 @@ class Context:
 
     @cached_property
     def kadm (self):
-        return Kadm()
+        return Kadm(ccache=self.operator.kadmin_ccache)
 
     @cached_property
     def kubeseal (self):

--- a/lib/amrc/factoryplus/krbkeys/context.py
+++ b/lib/amrc/factoryplus/krbkeys/context.py
@@ -35,6 +35,10 @@ class Context:
         current_context.reset(self.token)
         return False
 
+    @property
+    def fplus (self):
+        return self.operator.fplus
+
     @cached_property
     def k8s (self):
         return K8s()

--- a/lib/amrc/factoryplus/krbkeys/kadmin.py
+++ b/lib/amrc/factoryplus/krbkeys/kadmin.py
@@ -12,9 +12,9 @@ import  kadmin
 from    .util       import log
 
 class Kadm:
-    def __init__ (self, kadm=None):
+    def __init__ (self, kadm=None, ccache=None):
         if kadm is None:
-            self.kadm = kadmin.init_with_ccache()
+            self.kadm = kadmin.init_with_ccache(None, ccache)
         else:
             self.kadm = kadm
 

--- a/lib/amrc/factoryplus/krbkeys/secrets.py
+++ b/lib/amrc/factoryplus/krbkeys/secrets.py
@@ -2,51 +2,89 @@
 # Secret handling
 # Copyright 2023 AMRC
 
+import  logging
 import  typing
 
 from    .context    import kk_ctx
-from    .util       import fields, hidden, log
+from    .util       import dslice, fields, hidden, log
 
 @fields
 class SecretRef:
     ns:         str
     name:       str
     key:        str
-    seal:       str
-    cert:       bytes = hidden
 
     @property
     def splat (self):
         return self.ns, self.name, self.key
 
     def can_read (self):
-        return not self.seal
+        raise NotImplementedError()
 
     def maybe_read (self):
-        if self.seal:
-            return None
-        
+        raise NotImplementedError()
+
+    def verify_writable (self):
+        raise NotImplementedError()
+
+    def write (self, data):
+        raise NotImplementedError()
+
+    def remove (self):
+        raise NotImplementedError()
+
+    @staticmethod
+    def from_spec (ns, name, spec):
+        secret, seal = dslice(spec, "secret", "sealWith")
+        if secret is None:
+            log("Default secrets are deprecated", level=logging.WARNING)
+            oper = kk_ctx().operator
+            _, sec_name, sec_key = oper.get_secret_for(ns, name, spec)
+        else:
+            sec_name, sec_key = secret.split("/")
+
+        splat = { "ns": ns, "name": sec_name, "key": sec_key }
+        if seal:
+            return SealedSecret(**splat, seal=seal)
+        return LocalSecret(**splat)
+
+class LocalSecret (SecretRef):
+    def can_read (self):
+        return True
+
+    def maybe_read (self):
         ns, name, key = self.splat
         return kk_ctx().k8s.read_secret(ns, name, key)
 
     def verify_writable (self):
-        if self.seal:
-            ks = kk_ctx().kubeseal
-            self.cert = ks.fetch_cert(self.ns, self.seal)
-            ks.find_sealed_secret(self.ns, self.name, create=False, mine=True)
-        else:
-            kk_ctx().k8s.find_secret(self.ns, self.name, create=False, mine=True)
+        kk_ctx().k8s.find_secret(self.ns, self.name, create=False, mine=True)
 
     def write (self, data):
-        if self.seal:
-            kk_ctx().kubeseal.create_sealed_secret(self.cert, *self.splat, data)
-        else:
-            kk_ctx().k8s.update_secret(*self.splat, data)
+        kk_ctx().k8s.update_secret(*self.splat, data)
 
     def remove (self):
         ns, name, key = self.splat
-        if self.seal:
-            kk_ctx().kubeseal.maybe_delete_sealed_secret(ns, name, key)
-        else:
-            kk_ctx().k8s.remove_secret(ns, name, key)
+        kk_ctx().k8s.remove_secret(ns, name, key)
 
+@fields
+class SealedSecret (SecretRef):
+    seal:       str
+    cert:       bytes = hidden
+
+    def can_read (self):
+        return False
+
+    def maybe_read (self):
+        return None
+
+    def verify_writable (self):
+        ks = kk_ctx().kubeseal
+        self.cert = ks.fetch_cert(self.ns, self.seal)
+        ks.find_sealed_secret(self.ns, self.name, create=False, mine=True)
+
+    def write (self, data):
+        kk_ctx().kubeseal.create_sealed_secret(self.cert, *self.splat, data)
+
+    def remove (self):
+        ns, name, key = self.splat
+        kk_ctx().kubeseal.maybe_delete_sealed_secret(ns, name, key)

--- a/lib/amrc/factoryplus/krbkeys/spec.py
+++ b/lib/amrc/factoryplus/krbkeys/spec.py
@@ -31,14 +31,7 @@ class InternalSpec:
         self.kind, self.preset = keyops.TYPE_MAP[spec['type']]
         self.keep_old = bool(spec.get("keepOldKeys"))
 
-        secret, seal = dslice(spec, "secret", "sealWith")
-        if secret is None:
-            log("Default secrets are deprecated", level=logging.WARNING)
-            oper = kk_ctx().operator
-            _, sec_name, sec_key = oper.get_secret_for(ns, name, spec)
-        else:
-            sec_name, sec_key = secret.split("/")
-        self.secret = SecretRef(ns=ns, name=sec_name, key=sec_key, seal=seal)
+        self.secret = SecretRef.from_spec(ns, name, spec)
 
     @property
     def principal (self):

--- a/lib/amrc/factoryplus/service_client/edge_deployment.py
+++ b/lib/amrc/factoryplus/service_client/edge_deployment.py
@@ -44,5 +44,8 @@ class EdgeDeployment (ServiceInterface):
     def delete_secret (self, **kw):
         url = SecretUrl(**kw)
         st, _ = self.fetch(method="DELETE", **url.params)
-        if st != 204:
-            self.error(f"Can't delete secret {url.path}", st)
+        if st == 404:
+            return False
+        if st == 204:
+            return True
+        self.error(f"Can't delete secret {url.path}", st)

--- a/lib/amrc/factoryplus/service_client/edge_deployment.py
+++ b/lib/amrc/factoryplus/service_client/edge_deployment.py
@@ -2,12 +2,32 @@
 # Edge Deployment service interface
 # Copyright 2023 AMRC
 
-import logging
+from    dataclasses         import dataclass, field
+import  logging
 
 from .service_interface     import ServiceInterface
 from ..                     import uuids
 
 log = logging.getLogger(__name__)
+
+@dataclass
+class SecretUrl:
+    cluster: str
+    namespace: str
+    name: str
+    key: str
+    dryrun: bool = field(default=False)
+
+    @property
+    def path (s):
+        return f"{s.namespace}/{s.name}/{s.key}"
+
+    @property
+    def params (s):
+        return {
+            "url": f"v1/cluster/{s.cluster}/secret/{s.path}",
+            "params": { "dryrun": "true" if s.dryrun else None },
+        };
 
 class EdgeDeployment (ServiceInterface):
     def __init__ (self, fplus, **kw):
@@ -15,15 +35,14 @@ class EdgeDeployment (ServiceInterface):
 
         self.service = uuids.Service.EdgeDeployment
 
-    def seal_secret (self, cluster, namespace, name, key, content):
-        st, _ = self.fetch(method="PUT",
-            url=f"v1/cluster/{cluster}/secret/{namespace}/{name}/{key}",
-            data=content)
+    def seal_secret (self, content, **kw):
+        url = SecretUrl(**kw)
+        st, _ = self.fetch(method="PUT", data=content, **url.params)
         if st != 204:
-            self.error(f"Can't seal secret {namespace}/{name}/{key}", st)
+            self.error(f"Can't seal secret {url.path}", st)
 
-    def delete_secret (self, cluster, namespace, name, key):
-        st, _ = self.fetch(method="DELETE",
-            url=f"v1/cluster/{cluster}/secret/{namespace}/{name}/{key}")
+    def delete_secret (self, **kw):
+        url = SecretUrl(**kw)
+        st, _ = self.fetch(method="DELETE", **url.params)
         if st != 204:
-            self.error(f"Can't delete secret {namespace}/{name}/{key}", st)
+            self.error(f"Can't delete secret {url.path}", st)

--- a/lib/amrc/factoryplus/uuids.py
+++ b/lib/amrc/factoryplus/uuids.py
@@ -12,6 +12,7 @@ App = SimpleNamespace(
     Registration=UUID("cb40bed5-49ad-4443-a7f5-08c75009da8f"),
     Info=UUID("64a8bfa9-7772-45c4-9d1a-9e6290690957"),
     SparkplugAddress=UUID("8e32801b-f35a-4cbf-a5c3-2af64d3debd7"),
+    EdgeCluster=UUID("bdb13634-0b3d-4e38-a065-9d88c12ee78d"),
 )
 
 Class = SimpleNamespace(


### PR DESCRIPTION
Update the CRD to accept a reference to an edge cluster to seal the secret to.

Contact the Edge Deployment Operator to seal the secret and transport it to the edge cluster.

NOTE: this requires an adjustment to the deployment. `k5start` must be run twice, as we need two separate ccaches, one for talking to kadmind and one for talking to everything else.