### PR TITLE
Create accounts in the F+ databases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ config.mk
 
 # IDE
 .idea/
+
+# Python
+__pycache__

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG kubeseal_ver=0.19.5
 
 RUN apk add curl python3 py3-pip python3-dev gcc musl-dev krb5 krb5-dev \
     && pip install -t /usr/local/python krb5 python-kadmV kubernetes kopf \
-        requests requests-cache requests-kerberos \
+        optional.py requests requests-cache requests-kerberos \
     && curl -L https://github.com/bitnami-labs/sealed-secrets/releases/download/v${kubeseal_ver}/kubeseal-${kubeseal_ver}-linux-amd64.tar.gz | tar -xzvf - -C /usr/local/bin kubeseal
 
 FROM alpine

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,8 @@ suffix?=
 registry?=ghcr.io/amrc-factoryplus
 repo?=acs-kerberos-keys
 
+kubectl?=kubectl
+
 tag=${registry}/${repo}:${version}${suffix}
 
 all: build push
@@ -31,12 +33,12 @@ ifdef deployment
 deploy: all restart logs
 
 restart:
-	kubectl rollout restart deploy/"${deployment}"
-	kubectl rollout status deploy/"${deployment}"
+	${kubectl} rollout restart deploy/"${deployment}"
+	${kubectl} rollout status deploy/"${deployment}"
 	sleep 2
 
 logs:
-	kubectl logs -f deploy/"${deployment}" -c operator
+	${kubectl} logs -f deploy/"${deployment}" -c operator
 
 else
 

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 -include config.mk
 
-version?=1.0.3
+version?=1.2.0
 suffix?=
 registry?=ghcr.io/amrc-factoryplus
 repo?=acs-kerberos-keys

--- a/bin/krb-keys.sh
+++ b/bin/krb-keys.sh
@@ -10,6 +10,11 @@ split () {
     done
 }
 
+if [ -z "$WATCH_NAMESPACES" ]
+then
+    WATCH_NAMESPACES="$(cat /run/secrets/kubernetes.io/serviceaccount/namespace)"
+fi
+
 ns_args="$(split "$WATCH_NAMESPACES" , -n)"
 
 kopf run --standalone $ns_args -m amrc.factoryplus.krbkeys

--- a/crd/kerberos-keys.yaml
+++ b/crd/kerberos-keys.yaml
@@ -25,11 +25,8 @@ spec:
                 -   name: Secret
                     jsonPath: ".spec.secret"
                     type: string
-                -   name: SealWith
-                    jsonPath: ".spec.sealWith"
-                    type: string
-                -   name: Cluster
-                    jsonPath: ".spec.cluster"
+                -   name: UUID
+                    jsonPath: ".spec.account.uuid"
                     type: string
             schema:
                 openAPIV3Schema:
@@ -43,6 +40,7 @@ spec:
                                 - rule: "self.type in ['Random', 'Disabled'] || !has(self.keepOldKeys)"
                                 - rule: "has(self.secret) || !(has(self.sealWith) || has(self.cluster))"
                                 - rule: "has(self.secret) || self.type in ['Disabled', 'Random', 'Password', 'PresetPassword']"
+                                - rule: "!(has(self.account) && has(self.additionalPrincipals))"
                             required: [type, principal]
                             properties:
                                 type:
@@ -107,6 +105,27 @@ spec:
                                                 The namespace to seal the secret into. Defaults to
                                                 the cluster default namespace from the ConfigDB.
                                             type: string
+                                account:
+                                    description: >
+                                        Create an account in the Factory+ databases.
+                                    type: object
+                                    required: [uuid, class]
+                                    properties:
+                                        uuid:
+                                            description: The account UUID.
+                                            type: string
+                                            format: uuid
+                                        class:
+                                            description: The class UUID to use for the account.
+                                            type: string
+                                            format: uuid
+                                        name:
+                                            description: The GI name to give the account UUID.
+                                            type: string
+                                        groups:
+                                            description: Auth service groups to add the account to.
+                                            type: array
+                                            items: { type: string, format: uuid }
                         status:
                             type: object
                             x-kubernetes-preserve-unknown-fields: true

--- a/crd/kerberos-keys.yaml
+++ b/crd/kerberos-keys.yaml
@@ -25,9 +25,12 @@ spec:
         - name: Secret
           jsonPath: ".spec.secret"
           type: string
-        - name: UUID
+        - name: Account UUID
           jsonPath: ".spec.account.uuid"
           type: string
+        - name: Account class
+          type: string
+          jsonPath: ".spec.account.class"
       schema:
         openAPIV3Schema:
           type: object
@@ -133,6 +136,21 @@ spec:
                       description: Auth service groups to add the account to.
                       type: array
                       items: { type: string, format: uuid }
+                    aces:
+                      description: ACEs to add for this account.
+                      type: array
+                      items:
+                        type: object
+                        required: [permission, target]
+                        properties:
+                          permission:
+                            description: The permission to grant.
+                            type: string
+                            format: uuid
+                          target:
+                            description: The target to grant the permission on.
+                            type: string
+                            format: uuid
             status:
               type: object
               x-kubernetes-preserve-unknown-fields: true

--- a/crd/kerberos-keys.yaml
+++ b/crd/kerberos-keys.yaml
@@ -1,133 +1,133 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-    name: kerberos-keys.factoryplus.app.amrc.co.uk
+  name: kerberos-keys.factoryplus.app.amrc.co.uk
 spec:
-    group: factoryplus.app.amrc.co.uk
-    names:
-        kind: KerberosKey
-        plural: kerberos-keys
-        shortNames: [krb, krbs]
-        categories:
-            - all
-    scope: Namespaced
-    versions:
-        -   name: v1
-            served: true
-            storage: true
-            additionalPrinterColumns:
-                -   name: Type
-                    jsonPath: ".spec.type"
+  group: factoryplus.app.amrc.co.uk
+  names:
+    kind: KerberosKey
+    plural: kerberos-keys
+    shortNames: [krb, krbs]
+    categories:
+      - all
+  scope: Namespaced
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      additionalPrinterColumns:
+        - name: Type
+          jsonPath: ".spec.type"
+          type: string
+        - name: Principal
+          jsonPath: ".spec.principal"
+          type: string
+        - name: Secret
+          jsonPath: ".spec.secret"
+          type: string
+        - name: UUID
+          jsonPath: ".spec.account.uuid"
+          type: string
+      schema:
+        openAPIV3Schema:
+          type: object
+          required: [spec]
+          properties:
+            spec:
+              type: object
+              x-kubernetes-validations:
+                - rule: "self.type in ['Random', 'Disabled'] || !has(self.additionalPrincipals)"
+                - rule: "self.type in ['Random', 'Disabled'] || !has(self.keepOldKeys)"
+                - rule: "has(self.secret) || !(has(self.sealWith) || has(self.cluster))"
+                - rule: "has(self.secret) || self.type in ['Disabled', 'Random', 'Password', 'PresetPassword']"
+                - rule: "!(has(self.account) && has(self.additionalPrincipals))"
+              required: [type, principal]
+              properties:
+                type:
+                  description: >
+                    The kind of principal to create. Random is a fully random key which
+                    will be recorded as a keytab in the keytabs secret. Password generates
+                    a random (machine) password and records it in the passwords secret.
+                    PresetPassword expects a password to have already been recorded in the
+                    passwords secret; this password will be used as-is. 
+                  type: string
+                  enum: [Disabled, Random, Password, PresetPassword, Trust, PresetTrust]
+                principal:
+                  description: The Kerberos principal name.
+                  type: string
+                additionalPrincipals:
+                  description: >
+                    Additional principals to include in the keytab (useful for multi-homed
+                    servers). Only valid with type Random.
+                  type: array
+                  items:
                     type: string
-                -   name: Principal
-                    jsonPath: ".spec.principal"
-                    type: string
-                -   name: Secret
-                    jsonPath: ".spec.secret"
-                    type: string
-                -   name: UUID
-                    jsonPath: ".spec.account.uuid"
-                    type: string
-            schema:
-                openAPIV3Schema:
-                    type: object
-                    required: [spec]
-                    properties:
-                        spec:
-                            type: object
-                            x-kubernetes-validations:
-                                - rule: "self.type in ['Random', 'Disabled'] || !has(self.additionalPrincipals)"
-                                - rule: "self.type in ['Random', 'Disabled'] || !has(self.keepOldKeys)"
-                                - rule: "has(self.secret) || !(has(self.sealWith) || has(self.cluster))"
-                                - rule: "has(self.secret) || self.type in ['Disabled', 'Random', 'Password', 'PresetPassword']"
-                                - rule: "!(has(self.account) && has(self.additionalPrincipals))"
-                            required: [type, principal]
-                            properties:
-                                type:
-                                    description: >
-                                        The kind of principal to create. Random is a fully random key which
-                                        will be recorded as a keytab in the keytabs secret. Password generates
-                                        a random (machine) password and records it in the passwords secret.
-                                        PresetPassword expects a password to have already been recorded in the
-                                        passwords secret; this password will be used as-is. 
-                                    type: string
-                                    enum: [Disabled, Random, Password, PresetPassword, Trust, PresetTrust]
-                                principal:
-                                    description: The Kerberos principal name.
-                                    type: string
-                                additionalPrincipals:
-                                    description: >
-                                        Additional principals to include in the keytab (useful for multi-homed
-                                        servers). Only valid with type Random.
-                                    type: array
-                                    items:
-                                        type: string
-                                keepOldKeys:
-                                    description: Keep old keys available in the keytab.
-                                    type: boolean
-                                secret:
-                                    description: >
-                                        The name of the secret and key to store the keytab/password
-                                        for this principal in, in the format 'secret/key'. The
-                                        secret will be located in the same namespace as this object.
+                keepOldKeys:
+                  description: Keep old keys available in the keytab.
+                  type: boolean
+                secret:
+                  description: >
+                    The name of the secret and key to store the keytab/password
+                    for this principal in, in the format 'secret/key'. The
+                    secret will be located in the same namespace as this object.
 
-                                        Defaults to the secret configured in the operator for
-                                        keytabs or passwords and the name of this object as key.
-                                        This default should be considered deprecated, and will only
-                                        be applied for objects in the operator's default namespace
-                                        where the default secrets are.
-                                    type: string
-                                    pattern: "^[a-z0-9.-]+/[a-zA-Z0-9._-]+$"
-                                sealWith:
-                                    description: >
-                                        The name of a ConfigMap entry to seal the created secret
-                                        with, in the format 'configmap/key'. This ConfigMap entry
-                                        should contain a PEM-encoded X.509 certificate to sign to.
-                                        This will create a SealedSecret object rather than a Secret.
-                                        The ConfigMap needs to be in the same namespace as this
-                                        object.
-                                    type: string
-                                    pattern: "^[a-z0-9.-]+/[a-zA-Z0-9._-]+$"
-                                cluster:
-                                    description: >
-                                        The remote cluster to send the secret to. The secret itself
-                                        will be handed over to the Edge Deployment operator for
-                                        transfer to the remote cluster.
-                                    type: object
-                                    required: [uuid]
-                                    properties:
-                                        uuid:
-                                            description: The cluster UUID.
-                                            type: string
-                                            format: uuid
-                                        namespace:
-                                            description: >
-                                                The namespace to seal the secret into. Defaults to
-                                                the cluster default namespace from the ConfigDB.
-                                            type: string
-                                account:
-                                    description: >
-                                        Create an account in the Factory+ databases.
-                                    type: object
-                                    required: [uuid, class]
-                                    properties:
-                                        uuid:
-                                            description: The account UUID.
-                                            type: string
-                                            format: uuid
-                                        class:
-                                            description: The class UUID to use for the account.
-                                            type: string
-                                            format: uuid
-                                        name:
-                                            description: The GI name to give the account UUID.
-                                            type: string
-                                        groups:
-                                            description: Auth service groups to add the account to.
-                                            type: array
-                                            items: { type: string, format: uuid }
-                        status:
-                            type: object
-                            x-kubernetes-preserve-unknown-fields: true
-            subresources:
-                status: {}
+                    Defaults to the secret configured in the operator for
+                    keytabs or passwords and the name of this object as key.
+                    This default should be considered deprecated, and will only
+                    be applied for objects in the operator's default namespace
+                    where the default secrets are.
+                  type: string
+                  pattern: "^[a-z0-9.-]+/[a-zA-Z0-9._-]+$"
+                sealWith:
+                  description: >
+                    The name of a ConfigMap entry to seal the created secret
+                    with, in the format 'configmap/key'. This ConfigMap entry
+                    should contain a PEM-encoded X.509 certificate to sign to.
+                    This will create a SealedSecret object rather than a Secret.
+                    The ConfigMap needs to be in the same namespace as this
+                    object.
+                  type: string
+                  pattern: "^[a-z0-9.-]+/[a-zA-Z0-9._-]+$"
+                cluster:
+                  description: >
+                    The remote cluster to send the secret to. The secret itself
+                    will be handed over to the Edge Deployment operator for
+                    transfer to the remote cluster.
+                  type: object
+                  required: [uuid]
+                  properties:
+                    uuid:
+                      description: The cluster UUID.
+                      type: string
+                      format: uuid
+                    namespace:
+                      description: >
+                        The namespace to seal the secret into. Defaults to
+                        the cluster default namespace from the ConfigDB.
+                      type: string
+                account:
+                  description: >
+                    Create an account in the Factory+ databases.
+                  type: object
+                  required: [uuid, class]
+                  properties:
+                    uuid:
+                      description: The account UUID.
+                      type: string
+                      format: uuid
+                    class:
+                      description: The class UUID to use for the account.
+                      type: string
+                      format: uuid
+                    name:
+                      description: The GI name to give the account UUID.
+                      type: string
+                    groups:
+                      description: Auth service groups to add the account to.
+                      type: array
+                      items: { type: string, format: uuid }
+            status:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+      subresources:
+        status: {}

--- a/crd/kerberos-keys.yaml
+++ b/crd/kerberos-keys.yaml
@@ -109,14 +109,21 @@ spec:
                   description: >
                     Create an account in the Factory+ databases.
                   type: object
-                  required: [uuid, class]
+                  x-kubernetes-validations:
+                    - rule: "has(self.uuid) || has(self.class)"
+                    - rule: "has(self.class) || !has(self.name)"
                   properties:
                     uuid:
-                      description: The account UUID.
+                      description: >
+                        The account UUID. If omitted the class must be
+                        specified and a new account will be created.
                       type: string
                       format: uuid
                     class:
-                      description: The class UUID to use for the account.
+                      description: >
+                        The class UUID to use for the account. If
+                        omitted the account UUID must already exist in
+                        the ConfigDB.
                       type: string
                       format: uuid
                     name:

--- a/lib/amrc/factoryplus/krbkeys/__init__.py
+++ b/lib/amrc/factoryplus/krbkeys/__init__.py
@@ -13,8 +13,8 @@ import  kopf
 
 from    amrc.factoryplus    import ServiceClient
 
+from .              import event
 from .context       import Context
-from .event         import RekeyEvent, TrimKeysEvent
 from .util          import Identifiers, log
 
 CRD = (Identifiers.DOMAIN, Identifiers.CRD_VERSION, Identifiers.CRD_PLURAL)
@@ -37,12 +37,14 @@ class KrbKeys:
 
     def register_handlers (self):
         log("Registering handlers")
-        kopf_crud("rekey", self.process_event(RekeyEvent))
+        kopf_crud("rekey", self.process_event(event.Rekey))
         kopf.on.timer(*CRD,
             id="trim_keys",
             interval=self.expire_old_keys/2,
             labels={Identifiers.HAS_OLD_KEYS: "true"}
-        )(self.process_event(TrimKeysEvent))
+        )(self.process_event(event.TrimKeys))
+        kopf_crud("account_uuid", self.process_event(event.AccUuid))
+        kopf_crud("reconcile_account", self.process_event(event.Account))
 
     def run (self):
         self.register_handlers()

--- a/lib/amrc/factoryplus/krbkeys/account.py
+++ b/lib/amrc/factoryplus/krbkeys/account.py
@@ -10,16 +10,18 @@ from    optional    import Optional
 from    amrc.factoryplus    import ServiceError, uuids
 
 from    .context    import kk_ctx
-from    .util       import fields, log
+from    .util       import fields, immutable, log
 
-@fields
+@immutable
 class ACE:
     permission: UUID
     target: UUID
 
-    def __init__ (self, spec):
-        self.permission = UUID(spec["permission"])
-        self.target = UUID(spec["target"])
+    @classmethod
+    def of (cls, spec):
+        return cls(
+            permission=UUID(spec["permission"]),
+            target=UUID(spec["target"]))
 
 @fields
 class FPAccount:
@@ -43,7 +45,7 @@ class FPAccount:
         self.groups = set(UUID(g) for g in groups)
 
         aces = spec.get("aces", []);
-        self.aces = set(ACE(a) for a in aces)
+        self.aces = set(ACE.of(a) for a in aces)
 
     @classmethod
     def fromSpec (cls, spec, uuid):

--- a/lib/amrc/factoryplus/krbkeys/account.py
+++ b/lib/amrc/factoryplus/krbkeys/account.py
@@ -5,7 +5,7 @@
 import  typing
 from    uuid        import UUID
 
-from    amrc.factoryplus    import ServiceError
+from    amrc.factoryplus    import ServiceError, uuids
 
 from    .context    import kk_ctx
 from    .util       import fields, log
@@ -37,6 +37,9 @@ class FPAccount:
 
         log(f"Creating account object in class {self.klass}")
         fp.configdb.create_object(self.klass, self.uuid)
+        if self.name is not None:
+            fp.configdb.patch_config(uuids.App.Info, self.uuid,
+                { "name": self.name })
 
         # XXX This is not atomic, but this is unavoidable with the
         # current auth service API.

--- a/lib/amrc/factoryplus/krbkeys/account.py
+++ b/lib/amrc/factoryplus/krbkeys/account.py
@@ -23,8 +23,8 @@ class FPAccount:
 
         acc = spec["account"]
 
-        self.uuid = acc.get("uuid", annotation)
-        self.klass = acc.get("class")
+        self.uuid = UUID(acc.get("uuid", annotation))
+        self.klass = UUID(acc.get("class"))
         self.name = acc.get("name")
 
         groups = acc.get("groups", []);
@@ -64,10 +64,7 @@ class FPAccount:
             log(f"Updating auth principal mapping for {self.uuid} to {self.principal}")
             if ids is not None:
                 auth.delete_principal(self.uuid)
-            auth.add_principal({
-                "uuid": self.uuid, 
-                "kerberos": self.principal,
-            })
+            auth.add_principal(self.uuid, kerberos=self.principal)
 
         for grp in self.groups:
             log(f"Adding {self.uuid} to {grp}")

--- a/lib/amrc/factoryplus/krbkeys/account.py
+++ b/lib/amrc/factoryplus/krbkeys/account.py
@@ -1,0 +1,40 @@
+# Factory+ / AMRC Connectivity Stack (ACS) KerberosKey management operator
+# Internal spec class
+# Copyright 2023 AMRC
+
+import  typing
+from    uuid        import UUID
+
+from    .context    import kk_ctx
+from    .util       import fields, log
+
+@fields
+class FPAccount:
+    principal: str
+    uuid: UUID
+    klass: UUID
+    name: str | None
+    groups: list[UUID] | None
+
+    def __init__ (self, spec):
+        self.principal = spec["principal"]
+
+        acc = spec["account"]
+
+        self.uuid = acc["uuid"]
+        self.klass = acc["class"]
+        self.name = acc.get("name", None)
+
+        groups = acc.get("groups", None);
+        self.groups = None if groups is None \
+            else [UUID(g) for g in groups]
+
+    def reconcile (self):
+        log(f"Reconcile account {self}")
+
+    def remove (self, new):
+        log(f"Maybe remove account: {self} -> {new}")
+        if new is not None and self.uuid == new.uuid:
+            log("UUIDs match, ignoring")
+            return
+        log(f"Removing account {self.uuid}")

--- a/lib/amrc/factoryplus/krbkeys/account.py
+++ b/lib/amrc/factoryplus/krbkeys/account.py
@@ -31,6 +31,9 @@ class FPAccount:
 
     def reconcile (self):
         log(f"Reconcile account {self}")
+        fp = kk_ctx().fplus
+
+        fp.configdb.create_object(self.klass, self.uuid)
 
     def remove (self, new):
         log(f"Maybe remove account: {self} -> {new}")

--- a/lib/amrc/factoryplus/krbkeys/account.py
+++ b/lib/amrc/factoryplus/krbkeys/account.py
@@ -5,6 +5,8 @@
 import  typing
 from    uuid        import UUID
 
+from    amrc.factoryplus    import ServiceError
+
 from    .context    import kk_ctx
 from    .util       import fields, log
 
@@ -33,11 +35,34 @@ class FPAccount:
         log(f"Reconcile account {self}")
         fp = kk_ctx().fplus
 
+        log(f"Creating account object in class {self.klass}")
         fp.configdb.create_object(self.klass, self.uuid)
+
+        # XXX This is not atomic, but this is unavoidable with the
+        # current auth service API.
+        ids = fp.auth.get_principal(self.uuid)
+        if ids is not None and ids["kerberos"] == self.principal:
+            log(f"Principal is already correct in auth service")
+        else:
+            log(f"Updating auth principal mapping for {self.uuid} to {self.principal}")
+            if ids is not None:
+                fp.auth.delete_principal(self.uuid)
+            fp.auth.add_principal({
+                "uuid": self.uuid, 
+                "kerberos": self.principal,
+            })
 
     def remove (self, new):
         log(f"Maybe remove account: {self} -> {new}")
         if new is not None and self.uuid == new.uuid:
             log("UUIDs match, ignoring")
             return
+
+        fp = kk_ctx().fplus
+
         log(f"Removing account {self.uuid}")
+        try:
+            fp.auth.delete_principal(self.uuid)
+        except ServiceError as err:
+            if err.status != 404:
+                raise

--- a/lib/amrc/factoryplus/krbkeys/account.py
+++ b/lib/amrc/factoryplus/krbkeys/account.py
@@ -24,13 +24,13 @@ class FPAccount:
         self.uuid = uuid
         self.principal = principal
 
-        self.klass = Optional.of(acc.get("class")) \
+        self.klass = Optional.of(spec.get("class")) \
             .map(lambda u: UUID(u)) \
             .get_or_default(None)
 
-        self.name = acc.get("name")
+        self.name = spec.get("name")
 
-        groups = acc.get("groups", []);
+        groups = spec.get("groups", []);
         self.groups = set(UUID(g) for g in groups)
 
     @classmethod

--- a/lib/amrc/factoryplus/krbkeys/event.py
+++ b/lib/amrc/factoryplus/krbkeys/event.py
@@ -131,14 +131,18 @@ class Account (KrbKeyEvent):
         uuid = self.annotations.get(Identifiers.ACCOUNT_UUID)
         if uuid is None and self.reason != "delete":
             raise ValueError(f"Account UUID is not set yet")
+        
+        def mkacc (key):
+            return Optional.of(args.get(key)) \
+                .map(lambda ob: ob.get("spec")) \
+                .map(lambda spec: FPAccount.fromSpec(spec, uuid)) \
+                .get_or_default(None)
 
-        self.old = FPAccount.fromSpec(args["old"], uuid)
-        self.new = FPAccount.fromSpec(args["new"], uuid)
+        self.old = mkacc("old")
+        self.new = mkacc("new")
 
     def process (self):
-        if self.old == self.new:
-            log("No change to account")
-            return
+        log(f"Process account reconciliation {self.old} -> {self.new}")
 
         if self.old is not None:
             self.old.remove(self.new)

--- a/lib/amrc/factoryplus/krbkeys/event.py
+++ b/lib/amrc/factoryplus/krbkeys/event.py
@@ -52,7 +52,7 @@ class RekeyEvent (KrbKeyEvent):
         if self.new is None or self.new.disabled:
             return
         
-        status = self.new.reconcile_key(force=force)
+        status = self.new.reconcile(force=force)
 
         p_meta = self.patch.metadata
         p_meta.annotations[Identifiers.FORCE_REKEY] = None

--- a/lib/amrc/factoryplus/krbkeys/event.py
+++ b/lib/amrc/factoryplus/krbkeys/event.py
@@ -56,8 +56,10 @@ class RekeyEvent (KrbKeyEvent):
 
         p_meta = self.patch.metadata
         p_meta.annotations[Identifiers.FORCE_REKEY] = None
-        if status.has_old:
+        if status.has_old_keys:
             p_meta.labels[Identifiers.HAS_OLD_KEYS] = "true"
+        if status.account_uuid is not None:
+            p_meta.annotations[Identifiers.ACCOUNT_UUID] = status.account_uuid
 
 class TrimKeysEvent (KrbKeyEvent):
     def __init__ (self, args):

--- a/lib/amrc/factoryplus/krbkeys/event.py
+++ b/lib/amrc/factoryplus/krbkeys/event.py
@@ -59,7 +59,7 @@ class RekeyEvent (KrbKeyEvent):
         if status.has_old_keys:
             p_meta.labels[Identifiers.HAS_OLD_KEYS] = "true"
         if status.account_uuid is not None:
-            p_meta.annotations[Identifiers.ACCOUNT_UUID] = status.account_uuid
+            p_meta.annotations[Identifiers.ACCOUNT_UUID] = str(status.account_uuid)
 
 class TrimKeysEvent (KrbKeyEvent):
     def __init__ (self, args):

--- a/lib/amrc/factoryplus/krbkeys/event.py
+++ b/lib/amrc/factoryplus/krbkeys/event.py
@@ -59,7 +59,7 @@ class RekeyEvent (KrbKeyEvent):
         if status.has_old_keys:
             p_meta.labels[Identifiers.HAS_OLD_KEYS] = "true"
         if status.account_uuid is not None:
-            p_meta.annotations[Identifiers.ACCOUNT_UUID] = str(status.account_uuid)
+            p_meta.annotations[Identifiers.ACCOUNT_UUID] = status.account_uuid
 
 class TrimKeysEvent (KrbKeyEvent):
     def __init__ (self, args):

--- a/lib/amrc/factoryplus/krbkeys/util.py
+++ b/lib/amrc/factoryplus/krbkeys/util.py
@@ -22,6 +22,7 @@ class Identifiers:
 
     FORCE_REKEY = f"{APPID}/force-rekey"
     HAS_OLD_KEYS = f"{APPID}/has-old-keys"
+    ACCOUNT_UUID = f"{APPID}/account-uuid"
 
     MANAGED_BY = "app.kubernetes.io/managed-by"
 

--- a/lib/amrc/factoryplus/krbkeys/util.py
+++ b/lib/amrc/factoryplus/krbkeys/util.py
@@ -37,6 +37,7 @@ def log (*args, **kw):
 # I would like to use frozen and slots here, but it appears to break
 # super() in the __init__ methods.
 fields = dataclasses.dataclass()
+immutable = dataclasses.dataclass(frozen=True)
 hidden = dataclasses.field(init=False, default=None, compare=False, repr=False)
 
 class KtData:

--- a/lib/amrc/factoryplus/service_client/__init__.py
+++ b/lib/amrc/factoryplus/service_client/__init__.py
@@ -5,6 +5,7 @@
 from    functools       import cached_property
 import  logging
 
+from    .auth               import Auth
 from    .configdb           import ConfigDB
 from    .directory          import Directory
 from    .discovery          import Discovery
@@ -37,6 +38,10 @@ class ServiceClient:
                     opts[opt] = val
 
         self.opts = opts
+
+    @cached_property
+    def auth (self):
+        return Auth(self)
 
     @cached_property
     def configdb (self):

--- a/lib/amrc/factoryplus/service_client/auth.py
+++ b/lib/amrc/factoryplus/service_client/auth.py
@@ -1,0 +1,42 @@
+# Factory+ Python client library
+# Auth interface
+# Copyright 2023 AMRC
+
+import  logging
+from    uuid                import UUID
+
+from .service_interface     import ServiceInterface
+from ..                     import uuids
+
+log = logging.getLogger(__name__)
+
+class Auth (ServiceInterface):
+    def __init__ (self, fplus, **kw):
+        super().__init__(fplus, **kw);
+
+        self.service = uuids.Service.Authentication
+
+    def get_principal (self, uuid):
+        st, json = self.fetch(f"authz/principal/{uuid}")
+        if st == 404:
+            return
+        if st != 200:
+            self.error(f"Can't fetch principal {uuid}", st)
+        return json
+
+    def add_principal (self, identities):
+        st, _ = self.fetch(
+            method="POST",
+            url=f"authz/principal",
+            json=identities)
+        if st == 204:
+            return
+        self.error(f"Can't create principal {identities}", st)
+
+    def delete_principal (self, uuid):
+        st, _ = self.fetch(
+            method="DELETE",
+            url=f"authz/principal/{uuid}")
+        if st == 204:
+            return
+        self.error(f"Can't delete principal {uuid}", st)

--- a/lib/amrc/factoryplus/service_client/auth.py
+++ b/lib/amrc/factoryplus/service_client/auth.py
@@ -40,3 +40,19 @@ class Auth (ServiceInterface):
         if st == 204:
             return
         self.error(f"Can't delete principal {uuid}", st)
+
+    def add_to_group (self, group, member):
+        st, _ = self.fetch(
+            method="PUT",
+            url=f"authz/group/{group}/{member}")
+        if st == 204:
+            return
+        self.error(f"Can't add {member} to {group}", st)
+
+    def remove_from_group (self, group, member):
+        st, _ = self.fetch(
+            method="DELETE",
+            url=f"authz/group/{group}/{member}")
+        if st == 204:
+            return
+        self.error(f"Can't remove {member} from {group}", st)

--- a/lib/amrc/factoryplus/service_client/auth.py
+++ b/lib/amrc/factoryplus/service_client/auth.py
@@ -60,3 +60,33 @@ class Auth (ServiceInterface):
         if st == 204:
             return
         self.error(f"Can't remove {member} from {group}", st)
+
+    # This API endpoint is awful.
+    
+    def add_ace (self, principal, permission, target):
+        st, _ = self.fetch(
+            method="POST",
+            url=f"authz/ace",
+            json={
+                "action": "add",
+                "principal": str(principal),
+                "permission": str(permission),
+                "target": str(target),
+            })
+        if st == 204:
+            return
+        self.error(f"Can't add ACE {principal},{permission},{target}", st)
+    
+    def delete_ace (self, principal, permission, target):
+        st, _ = self.fetch(
+            method="POST",
+            url=f"authz/ace",
+            json={
+                "action": "delete",
+                "principal": str(principal),
+                "permission": str(permission),
+                "target": str(target),
+            })
+        if st == 204:
+            return
+        self.error(f"Can't add ACE {principal},{permission},{target}", st)

--- a/lib/amrc/factoryplus/service_client/auth.py
+++ b/lib/amrc/factoryplus/service_client/auth.py
@@ -24,14 +24,18 @@ class Auth (ServiceInterface):
             self.error(f"Can't fetch principal {uuid}", st)
         return json
 
-    def add_principal (self, identities):
+    def add_principal (self, uuid, kerberos=None):
+        json = { "uuid": str(uuid) }
+        if kerberos is not None:
+            json["kerberos"] = str(kerberos)
+
         st, _ = self.fetch(
             method="POST",
             url=f"authz/principal",
-            json=identities)
+            json=json)
         if st == 204:
             return
-        self.error(f"Can't create principal {identities}", st)
+        self.error(f"Can't create principal {json}", st)
 
     def delete_principal (self, uuid):
         st, _ = self.fetch(

--- a/lib/amrc/factoryplus/service_client/configdb.py
+++ b/lib/amrc/factoryplus/service_client/configdb.py
@@ -33,6 +33,16 @@ class ConfigDB (ServiceInterface):
             return
         self.error(f"Can't set {app} for {obj}", st)
 
+    def patch_config (self, app, obj, patch):
+        st, _ = self.fetch(
+            method="PATCH",
+            url=f"v1/app/{app}/object/{obj}",
+            content_type="application/merge-patch+json",
+            json=patch)
+        if st == 204:
+            return
+        self.error(f"Can't patch {app} for {obj}", st)
+
     def delete_config (self, app, obj):
         st, _ = self.fetch(
             method="DELETE",
@@ -54,4 +64,4 @@ class ConfigDB (ServiceInterface):
         if obj is None:
             self.error(f"Creating new {klass} failed", st)
         else:
-            self.error(f"Creating {obj} failed", st)
+            self.error(f"Creating {obj} of {klass} failed", st)

--- a/lib/amrc/factoryplus/service_client/configdb.py
+++ b/lib/amrc/factoryplus/service_client/configdb.py
@@ -51,7 +51,7 @@ class ConfigDB (ServiceInterface):
             return
         self.error(f"Can't remove {app} for {obj}", st)
 
-    def create_object (self, klass, obj, excl=False):
+    def create_object (self, klass, obj=None, excl=False):
         st, json = self.fetch(
             method="POST",
             url="v1/object",

--- a/lib/amrc/factoryplus/service_client/configdb.py
+++ b/lib/amrc/factoryplus/service_client/configdb.py
@@ -2,7 +2,8 @@
 # ConfigDB interface
 # Copyright 2023 AMRC
 
-import logging
+import  logging
+from    uuid                import UUID
 
 from .service_interface     import ServiceInterface
 from ..                     import uuids
@@ -40,7 +41,7 @@ class ConfigDB (ServiceInterface):
             return
         self.error(f"Can't remove {app} for {obj}", st)
 
-    def create_object (klass, obj, excl):
+    def create_object (self, klass, obj, excl=False):
         st, json = self.fetch(
             method="POST",
             url="v1/object",
@@ -49,16 +50,8 @@ class ConfigDB (ServiceInterface):
         if st == 200 and excl:
             self.error(f"Exclusive create of {obj} failed", st)
         if st == 201 or st == 200:
-            return json.uuid
+            return UUID(json["uuid"])
         if obj is None:
-            self.error(f"Creating new {klass} failed")
+            self.error(f"Creating new {klass} failed", st)
         else:
-            self.error(f"Creating {obj} failed")
-
-    def delete_object (obj):
-        st, _ = self.fetch(
-            method="DELETE",
-            url=f"v1/object/{obj}")
-        if st == 204:
-            return
-        self.error(f"Deleting {obj} failed")
+            self.error(f"Creating {obj} failed", st)

--- a/lib/amrc/factoryplus/service_client/configdb.py
+++ b/lib/amrc/factoryplus/service_client/configdb.py
@@ -52,10 +52,14 @@ class ConfigDB (ServiceInterface):
         self.error(f"Can't remove {app} for {obj}", st)
 
     def create_object (self, klass, obj=None, excl=False):
+        req = { "class": str(klass) }
+        if obj is not None:
+            req["uuid"] = str(obj)
+
         st, json = self.fetch(
             method="POST",
             url="v1/object",
-            json={ "class": klass, "uuid": obj })
+            json=req)
 
         if st == 200 and excl:
             self.error(f"Exclusive create of {obj} failed", st)

--- a/lib/amrc/factoryplus/service_client/service_error.py
+++ b/lib/amrc/factoryplus/service_client/service_error.py
@@ -21,3 +21,12 @@ class ServiceError (Exception):
         msg = super().__str__()
         st = f": {self.status}" if self.status is not None else ""
         return f"{srv}: {msg}{st}"
+
+    @classmethod
+    def catch (cls, codes, action):
+        try:
+            return action()
+        except cls as e:
+            if e.status in codes:
+                return
+            raise

--- a/lib/amrc/factoryplus/service_client/service_interface.py
+++ b/lib/amrc/factoryplus/service_client/service_interface.py
@@ -28,10 +28,10 @@ class ServiceInterface:
         headers = opts.pop("headers", {})
         headers["Accept"] = "application/json"
 
-        if "json" in opts:
-            headers["Content-Type"] = "application/json"
-        elif "content_type" in opts:
+        if "content_type" in opts:
             headers["Content-Type"] = opts.pop("content_type")
+        elif "json" in opts:
+            headers["Content-Type"] = "application/json"
         elif "data" in opts:
             headers["Content-Type"] = "application/octet-stream"
 


### PR DESCRIPTION
When deploying an edge cluster out of a Helm chart, a number of F+ accounts need to be created and granted appropriate permissions. Allow the krbkeys operator to handle this, by creating accounts and putting them into appropriate groups.

* Extend the CRD to allow F+ account information to be specified.
* Support both accounts we create entirely, e.g. the edge-sync account, and accounts that already exist and have a UUID, e.g. an account for an Edge Agent.