### PR TITLE
Bootstrap Kerberos for an edge cluster

### DIFF
--- a/lib/amrc/factoryplus/krbkeys/cluster.py
+++ b/lib/amrc/factoryplus/krbkeys/cluster.py
@@ -13,6 +13,8 @@ cluster = os.environ["CLUSTER_NAME"]
 realm = os.environ["REALM"]
 namespace = os.environ["NAMESPACE"]
 
+input("Press Return to continue...")
+
 print(f"Enrolling cluster {cluster} in {realm}")
 user = input("ACS admin user: ")
 passwd = getpass.getpass(prompt="Password: ")

--- a/lib/amrc/factoryplus/krbkeys/cluster.py
+++ b/lib/amrc/factoryplus/krbkeys/cluster.py
@@ -1,4 +1,5 @@
 import getpass
+import os
 import secrets
 
 import kadmin
@@ -8,9 +9,9 @@ from .kadmin import Kadm
 from .kubernetes import K8s
 from .util import KtData
 
-cluster = process.environ["CLUSTER_NAME"]
-realm = process.environ["REALM"]
-namespace = process.environ["NAMESPACE"]
+cluster = os.environ["CLUSTER_NAME"]
+realm = os.environ["REALM"]
+namespace = os.environ["NAMESPACE"]
 
 print(f"Enrolling cluster {cluster} in {realm}")
 user = input("ACS admin user: ")

--- a/lib/amrc/factoryplus/krbkeys/cluster.py
+++ b/lib/amrc/factoryplus/krbkeys/cluster.py
@@ -1,0 +1,36 @@
+import getpass
+import secrets
+
+import kadmin
+import kubernetes as k8s
+
+from .kadmin import Kadm
+from .kubernetes import K8s
+from .util import KtData
+
+cluster = process.environ["CLUSTER_NAME"]
+realm = process.environ["REALM"]
+namespace = process.environ["NAMESPACE"]
+
+print(f"Enrolling cluster {cluster} in {realm}")
+user = input("ACS admin user: ")
+passwd = getpass.getpass(prompt="Password: ")
+kadm_h = kadmin.init_with_password(user, passwd)
+kadm = Kadm(kadm=kadm_h)
+
+k8s.config.load_incluster_config()
+k8o = K8s()
+
+kt = KtData(contents=None)
+with kt.kt_name() as ktname:
+    kadm.create_keytab([f"op1krbkeys/{cluster}"], ktname)
+k8o.update_secret(ns=namespace, name="krb-keys-keytabs",
+    key="client", value=kt.contents)
+
+fluxusr = f"op1flux/{cluster}"
+fluxpw = secrets.token_urlsafe()
+kadm.set_password(fluxusr, fluxpw)
+k8o.update_secret(ns=namespace, name="flux-secrets", key="password", 
+    value=fluxpw.encode())
+k8o.update_secret(ns=namespace, name="flux-secrets", key="username",
+    value=fluxusr.encode())

--- a/lib/amrc/factoryplus/krbkeys/cluster.py
+++ b/lib/amrc/factoryplus/krbkeys/cluster.py
@@ -24,16 +24,21 @@ kadm = Kadm(kadm=kadm_h)
 k8s.config.load_incluster_config()
 k8o = K8s()
 
+kkusr = f"op1krbkeys/{cluster}@{realm}"
 kt = KtData(contents=None)
 with kt.kt_name() as ktname:
-    kadm.create_keytab([f"op1krbkeys/{cluster}"], ktname)
+    kadm.create_keytab([kkusr], ktname)
 k8o.update_secret(ns=namespace, name="krb-keys-keytabs",
     key="client", value=kt.contents)
+kadm.enable_princ(kkusr)
+print(f"Created krbkeys account {kkusr}")
 
-fluxusr = f"op1flux/{cluster}"
+fluxusr = f"op1flux/{cluster}@{realm}"
 fluxpw = secrets.token_urlsafe()
 kadm.set_password(fluxusr, fluxpw)
 k8o.update_secret(ns=namespace, name="flux-secrets", key="password", 
     value=fluxpw.encode())
 k8o.update_secret(ns=namespace, name="flux-secrets", key="username",
     value=fluxusr.encode())
+kadm.enable_princ(fluxusr)
+print(f"Created flux account {fluxusr}")

--- a/lib/amrc/factoryplus/krbkeys/event.py
+++ b/lib/amrc/factoryplus/krbkeys/event.py
@@ -131,9 +131,6 @@ class Account (KrbKeyEvent):
         deleting = self.reason == "delete"
 
         uuid = self.annotations.get(Identifiers.ACCOUNT_UUID)
-        if uuid is None and not deleting:
-            raise ValueError(f"Account UUID is not set yet")
-        
         def mkacc (key):
             return Optional.of(args.get(key)) \
                 .map(lambda ob: ob.get("spec")) \
@@ -146,6 +143,9 @@ class Account (KrbKeyEvent):
         # (unhelpful...).
         self.old = mkacc("old")
         self.new = None if deleting else mkacc("new")
+
+        if uuid is None and self.new is not None:
+            raise ValueError(f"Account UUID is not set yet")
 
     def process (self):
         log(f"Process account reconciliation {self.old} -> {self.new}")


### PR DESCRIPTION
Create a cluster bootstrap script which uses administrator kadmin credentials to create `op1krbkeys` and `op1flux` Kerberos principals and store their credentials on the local cluster. From here any additional principals needed can be pushed in KerberosKey objects via flux.

This script prompts for an admin password interactively. It is intended to be run under `kubectl attach` as part of the cluster boostrap process.