### PR TITLE
Create Sparkplug address entries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 -include config.mk
 
-version?=1.2.0
+version?=v1.3.0
 suffix?=
 registry?=ghcr.io/amrc-factoryplus
 repo?=acs-kerberos-keys

--- a/crd/kerberos-keys.yaml
+++ b/crd/kerberos-keys.yaml
@@ -151,6 +151,20 @@ spec:
                             description: The target to grant the permission on.
                             type: string
                             format: uuid
+                    sparkplug:
+                      description: Sparkplug Address entry to create
+                      type: object
+                      required: [node]
+                      properties:
+                        group:
+                          description: >
+                            Sparkplug Group ID. Optional for edge
+                            cluster krbkeys, where it defaults to the
+                            Group ID of the edge cluster.
+                          type: string
+                        node:
+                          description: Sparkplug Node ID
+                          type: string
             status:
               type: object
               x-kubernetes-preserve-unknown-fields: true

--- a/lib/amrc/factoryplus/krbkeys/__init__.py
+++ b/lib/amrc/factoryplus/krbkeys/__init__.py
@@ -10,8 +10,9 @@ import  os
 import  secrets
 
 import  kopf
+from    optional            import Optional
 
-from    amrc.factoryplus    import ServiceClient
+from    amrc.factoryplus    import ServiceClient, uuids
 
 from .              import event
 from .context       import Context
@@ -33,7 +34,13 @@ class KrbKeys:
         self.presets = env.get("PRESETS_SECRET")
         self.expire_old_keys = int(env.get("EXPIRE_OLD_KEYS", 86400))
         self.kadmin_ccache = env.get("KADMIN_CCNAME", None)
+
         self.fplus = ServiceClient(env=env)
+
+        self.cluster_group = Optional.of(env.get("CLUSTER_UUID")) \
+            .map(lambda cluster: self.fplus.configdb.get_config(
+                uuids.App.SparkplugAddress, cluster)) \
+            .map(lambda addr: addr["group_id"])
 
     def register_handlers (self):
         log("Registering handlers")

--- a/lib/amrc/factoryplus/krbkeys/account.py
+++ b/lib/amrc/factoryplus/krbkeys/account.py
@@ -83,13 +83,11 @@ class FPAccount:
 
         # If we don't have a class we aren't managing this object in the
         # ConfigDB. Someone else (the manager perhaps) is doing that.
-        if self.klass is None:
-            return
-
-        if self.name is not None:
+        if self.klass is not None and self.name is not None:
             cdb.patch_config(uuids.App.Info, self.uuid,
                 { "name": self.name, "deleted": None })
 
+        # We are always managing the Sparkplug address if it's requested
         if self.sparkplug is not None:
             group = self.sparkplug.group \
                 .or_else(lambda: kk_ctx().operator.cluster_group \

--- a/lib/amrc/factoryplus/service_client/configdb.py
+++ b/lib/amrc/factoryplus/service_client/configdb.py
@@ -30,7 +30,9 @@ class ConfigDB (ServiceInterface):
             url=f"v1/app/{app}/object/{obj}",
             json=json)
         if st == 204:
-            return
+            return False
+        if st == 201:
+            return True
         self.error(f"Can't set {app} for {obj}", st)
 
     def patch_config (self, app, obj, patch):


### PR DESCRIPTION
* Update the KerberosKey CRD to support specifying a Sparkplug address for the new account.
* Create Sparkplug Address entries in the ConfigDB.
* Allow the Group ID to default to the entry for the cluster UUID.