### PR TITLE
Don't attempt to trim keys for presets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,8 @@ ARG kubeseal_ver=0.19.5
 
 RUN apk add curl python3 py3-pip python3-dev gcc musl-dev krb5 krb5-dev \
     && pip install -t /usr/local/python krb5 python-kadmV kubernetes kopf \
-        optional.py requests requests-cache requests-kerberos \
+        "optional.py<2.0" \
+        requests requests-cache requests-kerberos \
     && curl -L https://github.com/bitnami-labs/sealed-secrets/releases/download/v${kubeseal_ver}/kubeseal-${kubeseal_ver}-linux-amd64.tar.gz | tar -xzvf - -C /usr/local/bin kubeseal
 
 FROM alpine

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 -include config.mk
 
-version?=v1.3.0
+version?=v1.3.1
 suffix?=
 registry?=ghcr.io/amrc-factoryplus
 repo?=acs-kerberos-keys

--- a/lib/amrc/factoryplus/krbkeys/event.py
+++ b/lib/amrc/factoryplus/krbkeys/event.py
@@ -60,7 +60,7 @@ class Rekey (KrbKeyEvent):
 
         p_meta = self.patch.metadata
         p_meta.annotations[Identifiers.FORCE_REKEY] = None
-        if status.has_old_keys:
+        if status.has_old:
             p_meta.labels[Identifiers.HAS_OLD_KEYS] = "true"
 
 class TrimKeys (KrbKeyEvent):

--- a/lib/amrc/factoryplus/krbkeys/spec.py
+++ b/lib/amrc/factoryplus/krbkeys/spec.py
@@ -13,10 +13,6 @@ from    .secrets    import SecretRef
 from    .util       import Identifiers, dslice, fields, hidden, log
 
 @fields
-class ReconcileStatus:
-    has_old_keys: bool = False
-
-@fields
 class InternalSpec:
     principals: list[str]
     secret: SecretRef
@@ -73,12 +69,6 @@ class InternalSpec:
             kadm.disable_princ(p)
 
     def reconcile (self, force=False):
-        status = ReconcileStatus()
-
-        status.has_old_keys = self.reconcile_key(force)
-        return status
-
-    def reconcile_key (self, force):
         kops = self.kind
         current = self.secret.maybe_read()
 
@@ -104,7 +94,7 @@ class InternalSpec:
 
         status = kops.generate_key(self, oldkey)
         self.secret.write(status.secret)
-        return status.has_old
+        return status
 
     def trim_keys (self):
         self.secret.verify_writable()


### PR DESCRIPTION
The operator was attempting to run `trim_keys` on Preset keys. This was failing because the Secrets were not writable by the operator.

The root cause was a bug introduced during refactoring of the account creation code.

Also forbid optional.py v2.0, newly uploaded on 13 March and with a different and useless API.